### PR TITLE
fix: add client_max_body_size in the nginx conf

### DIFF
--- a/ansible/roles/nginx/templates/bivouac-nginx.conf.j2
+++ b/ansible/roles/nginx/templates/bivouac-nginx.conf.j2
@@ -10,6 +10,7 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/{{ nginx_server_name }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ nginx_server_name }}/privkey.pem;
+    client_max_body_size 20M;
 
     location /api/ {
         proxy_pass http://127.0.0.1:{{ api_fastapi_server_port }}/;


### PR DESCRIPTION
Pour fixer une erreur 413 nginx `413 Request Entity Too Large`

pour info @sylvainbeo 