### PR TITLE
feat: zoom in on click markers (contamines area)

### DIFF
--- a/front/src/components/Localisation.jsx
+++ b/front/src/components/Localisation.jsx
@@ -764,6 +764,11 @@ export default function Localisation() {
                                 iconSize: [iconSize, iconSize],
                                 iconAnchor: iconAnchor,
                             })}
+                            eventHandlers={{
+                                click: () => {
+                                    map.flyTo([point.lat, point.lon], 18, {duration: 1.2});
+                                },
+                            }}
                         />
                     );
                 }


### PR DESCRIPTION
- lorsqu'on clique sur les marqueurs de la zone contamines, cela zoome sur la zone
- possibilité de changer la durée du `flyTo`


Démo : 
https://github.com/user-attachments/assets/d86fad41-88c3-45b7-9b4b-a3c50eac47aa

Pour info @sylvainbeo 
