### PR TITLE
feat: skip the quiz stage when it has already been completed

### DIFF
--- a/front/src/components/Localisation.jsx
+++ b/front/src/components/Localisation.jsx
@@ -23,7 +23,6 @@ import { ListSubheader } from '@mui/material';
 import zoomLocation from '../assets/img/zoom_location.svg';
 import { Dialog, DialogContent, DialogActions } from "@mui/material";
 import html2canvas from "html2canvas";
-// import leafletImage from 'leaflet-image';
 
 export default function Localisation() {
     const navigate = useNavigate();
@@ -43,6 +42,7 @@ export default function Localisation() {
     let resultsLocalisationData = resultsData.localisation;
     let resultsNbTentsZoningDate = resultsData.nb_tents_zoning_date;
     let resultsTwoNextAvailableDatesZoning = resultsData.two_next_available_dates_zoning;
+    let resultsQuizzCompleted = resultsData.quizzCompleted
     const maxLocations = 2;
     const [nbTentsZoningDate, setNbTentsZoningDate] = useState(resultsNbTentsZoningDate);
     const [nameCurrentAreaSelected, setNameCurrentAreaSelected] = useState("");
@@ -248,7 +248,7 @@ export default function Localisation() {
         navigate("/reservation-bivouac/" + previousPage);
     };
 
-    // Capture the locations and navigate to quizz page
+    // Capture the locations and navigate to quizz or summary page
     const nextStep = (event) => {
         let nextPage = event.target.name;
         const localisationData = store.getState().results.localisation;
@@ -321,7 +321,7 @@ export default function Localisation() {
                         data: capturedImagesArray,
                     }));
 
-                    // Navigate to the quiz page once captures are completed
+                    // Navigate to the quiz or summary page once captures are completed
                     navigate("/reservation-bivouac/" + nextPage);
                 });
             }
@@ -925,7 +925,7 @@ export default function Localisation() {
                 <Button
                     variant="outlined"
                     onClick={nextStep}
-                    name="quizz"
+                    name={resultsQuizzCompleted ? "thanks" : "quizz"}
                 >
                     {t("Next step")}
                 </Button>

--- a/front/src/stores/Results.js
+++ b/front/src/stores/Results.js
@@ -10,6 +10,7 @@ export const general = createSlice({
         capturedImages: [],
     },
     quizz: {},
+    quizzCompleted: false,
     reservation: {
         confirmed: false,
         output_message: ""
@@ -53,6 +54,9 @@ export const general = createSlice({
     clearLocalisationCapturedImages: (state) => {
         state.localisation.capturedImages = [];
     },
+    updateQuizzCompleted: (state) => {
+        state.quizzCompleted = true;
+    },
     resetResults: (state) => {
         state.infos = {};
         state.nb_tents_zoning_date = {};
@@ -62,10 +66,11 @@ export const general = createSlice({
             capturedImages: []
         };
         state.quizz = {};
+        state.quizzCompleted = false;
   },
 }
 });
 
-export const { updateResults, updateReservation, updateLocalisationPositions, updateLocalisationCapturedImages, clearLocalisationCapturedImages, resetResults } = general.actions;
+export const { updateResults, updateReservation, updateLocalisationPositions, updateLocalisationCapturedImages, clearLocalisationCapturedImages, updateQuizzCompleted, resetResults } = general.actions;
 
 export default general.reducer;


### PR DESCRIPTION
- lorsque l'utilisateur a déjà rempli le quizz, qu'il modifie la résa, il revient à la partie renseignements puis fait étape suivante pour la partie localisation
- avant : lorsqu'il clique sur étape suivante sur l'onglet localisation alors il repasse par le quizz
- après : lorsqu'il clique sur étape suivante sur l'onglet localisation alors il va directement au résumé car il a déjà rempli le quizz

Démo : 
https://github.com/user-attachments/assets/8b1f011d-036d-43ec-8694-93aade1f290d

Pour info @sylvainbeo 

