### PR TITLE
fix: freeze bug on export

### DIFF
--- a/front/src/components/Localisation.jsx
+++ b/front/src/components/Localisation.jsx
@@ -243,6 +243,9 @@ export default function Localisation() {
         } else {
             setDisplayAlert(false);
 
+            // Fix a freeze bug on export
+            mapRef.current.setView([45.86, 6.79], 10);
+
             // Set the overlay to prevent interaction with the map during the capture
             setDisplayOverlayCaptureImages(true)
             setDisableButtonNextStep(true);
@@ -268,7 +271,7 @@ export default function Localisation() {
                                     useCORS: true,
                                     allowTaint: true,
                                 });
-                                    const imageUrl = canvas.toDataURL("image/png");
+                                const imageUrl = canvas.toDataURL("image/png");
 
                                 capturedImagesArray.push(imageUrl);
                                 resolve();


### PR DESCRIPTION
Un bug a été constaté. Dans certains cas de figure, il y a un freeze au moment de l'export des captures d'écran. Les cas testés :
- cliquer sur le marqueur bleu pour zoomer puis placer la tente
- zoomer à la molette au maximum puis placer la tente (pas forcément sur les petites zones)
- zoomer à la molette au maximum puis dézoomer de 1 niveau et placer la tente (pas forcément sur les petites zones)
- zoomer à la molette au maximum puis dézoomer de 2 niveaux et placer la tente (pas forcément sur les petites zones)

Seul le dernier cas fonctionne.

Modification de la vue de la carte pour contourner ce bug

Déployé sur https://bivouac.oslandia.io 

cc @sylvainbeo 
